### PR TITLE
Update DataController.App.cs to change SignalRUpdateApp from public to private

### DIFF
--- a/CRM/Controllers/DataController.App.cs
+++ b/CRM/Controllers/DataController.App.cs
@@ -20,7 +20,7 @@ public partial class DataController
         return Ok(output);
     }
 
-    public async Task<bool> SignalRUpdateApp(DataObjects.SignalRUpdate update)
+    private async Task<bool> SignalRUpdateApp(DataObjects.SignalRUpdate update)
     {
         await Task.Delay(0); // Simulate a delay since this method has to be async. This can be removed once you implement your await logic.
         


### PR DESCRIPTION
This patch changes the new /CRM/Controllers/DataController.App.cs SignalRUpdateApp method which was introduced on 9/5/2025 in the DataController from public to private which stops a build error I am encountering.

Thanks
-Daniel